### PR TITLE
Don't process .css files with LESS

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function(file, opts) {
     paths: []
   }, opts);
 
-  if (!/\.css$|\.less$/.test(file)) {
+  if (!/\.less$/.test(file)) {
     return through();
   }
 


### PR DESCRIPTION
If there is ever invalid CSS from open source modules i.e. [video-js-css](https://github.com/videojs/video.js/blob/5fdcd4602bcb4b87bd977b6e4463b3a3443f32e3/src/css/ie8.css#L1) and Cartero sends the CSS to this transform stream, less-css-stream will throw an error because it tries to process it. 

Seems like we should only be accepting `.less` extensions anyway. 